### PR TITLE
Refactor action sampling inside env wrapper

### DIFF
--- a/scripts/envrionments/dmcs/dmcs_environment.py
+++ b/scripts/envrionments/dmcs/dmcs_environment.py
@@ -37,8 +37,8 @@ class DMCSEnvironment(GymEnvironment):
 
     def sample_action(self) -> int:
         return np.random.uniform(
-                self.min_action_value, self.max_action_value, size=self.action_num
-            )
+            self.min_action_value, self.max_action_value, size=self.action_num
+        )
 
     def set_seed(self, seed: int) -> None:
         self.env = suite.load(self.domain, self.task, task_kwargs={"random": seed})

--- a/scripts/envrionments/dmcs/dmcs_environment.py
+++ b/scripts/envrionments/dmcs/dmcs_environment.py
@@ -35,6 +35,11 @@ class DMCSEnvironment(GymEnvironment):
     def action_num(self) -> int:
         return self.env.action_spec().shape[0]
 
+    def sample_action(self) -> int:
+        return np.random.uniform(
+                self.min_action_value, self.max_action_value, size=self.action_num
+            )
+
     def set_seed(self, seed: int) -> None:
         self.env = suite.load(self.domain, self.task, task_kwargs={"random": seed})
 

--- a/scripts/envrionments/gym_environment.py
+++ b/scripts/envrionments/gym_environment.py
@@ -31,6 +31,10 @@ class GymEnvironment(metaclass=abc.ABCMeta):
         raise NotImplementedError("Override this method")
 
     @abc.abstractmethod
+    def sample_action(self):
+        raise NotImplementedError("Override this method")
+
+    @abc.abstractmethod
     def set_seed(self, seed):
         raise NotImplementedError("Override this method")
 

--- a/scripts/envrionments/openai/openai_environment.py
+++ b/scripts/envrionments/openai/openai_environment.py
@@ -37,6 +37,9 @@ class OpenAIEnvrionment(GymEnvironment):
             )
         return action_num
 
+    def sample_action(self) -> int:
+        return self.env.action_space.sample()
+
     def set_seed(self, seed: int) -> None:
         self.env.action_space.seed(seed)
         _, _ = self.env.reset(seed=seed)

--- a/scripts/envrionments/pyboy/mario/mario_environment.py
+++ b/scripts/envrionments/pyboy/mario/mario_environment.py
@@ -29,7 +29,9 @@ class MarioEnvironment(PyboyEnvironment):
         ]
 
     def sample_action(self) -> int:
-        return np.random.randint(0, len(self.valid_actions))
+        return np.random.uniform(
+                self.min_action_value, self.max_action_value, size=self.action_num
+            )
 
     def _stats_to_state(self, game_stats: Dict[str, int]) -> List:
         state: List = []

--- a/scripts/envrionments/pyboy/mario/mario_environment.py
+++ b/scripts/envrionments/pyboy/mario/mario_environment.py
@@ -30,8 +30,8 @@ class MarioEnvironment(PyboyEnvironment):
 
     def sample_action(self) -> int:
         return np.random.uniform(
-                self.min_action_value, self.max_action_value, size=self.action_num
-            )
+            self.min_action_value, self.max_action_value, size=self.action_num
+        )
 
     def _stats_to_state(self, game_stats: Dict[str, int]) -> List:
         state: List = []

--- a/scripts/envrionments/pyboy/mario/mario_environment.py
+++ b/scripts/envrionments/pyboy/mario/mario_environment.py
@@ -5,6 +5,7 @@ from pyboy import WindowEvent
 from util.configurations import GymEnvironmentConfig
 import numpy as np
 
+
 class MarioEnvironment(PyboyEnvironment):
     def __init__(self, config: GymEnvironmentConfig) -> None:
         super().__init__(config, rom_name="SuperMarioLand.gb", init_name="init.state")

--- a/scripts/envrionments/pyboy/mario/mario_environment.py
+++ b/scripts/envrionments/pyboy/mario/mario_environment.py
@@ -3,7 +3,7 @@ from typing import Dict, List
 from envrionments.pyboy.pyboy_environment import PyboyEnvironment
 from pyboy import WindowEvent
 from util.configurations import GymEnvironmentConfig
-
+import numpy as np
 
 class MarioEnvironment(PyboyEnvironment):
     def __init__(self, config: GymEnvironmentConfig) -> None:
@@ -26,6 +26,9 @@ class MarioEnvironment(PyboyEnvironment):
             WindowEvent.RELEASE_BUTTON_A,
             WindowEvent.RELEASE_BUTTON_B,
         ]
+
+    def sample_action(self) -> int:
+        return np.random.randint(0, len(self.valid_actions))
 
     def _stats_to_state(self, game_stats: Dict[str, int]) -> List:
         state: List = []

--- a/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
+++ b/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
@@ -4,7 +4,7 @@ from envrionments.pyboy.pokemon import pokemon_constants as pkc
 from envrionments.pyboy.pyboy_environment import PyboyEnvironment
 from pyboy import WindowEvent
 from util.configurations import GymEnvironmentConfig
-
+import numpy as np
 
 class PokemonEnvironment(PyboyEnvironment):
     def __init__(self, config: GymEnvironmentConfig) -> None:
@@ -28,6 +28,9 @@ class PokemonEnvironment(PyboyEnvironment):
             WindowEvent.RELEASE_BUTTON_B,
         ]
 
+    def sample_action(self) -> int:
+        return np.random.randint(0, len(self.valid_actions))
+    
     def _stats_to_state(self, game_stats: Dict[str, any]) -> List[any]:
         state: List[any] = []
         return state

--- a/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
+++ b/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
@@ -6,6 +6,7 @@ from pyboy import WindowEvent
 from util.configurations import GymEnvironmentConfig
 import numpy as np
 
+
 class PokemonEnvironment(PyboyEnvironment):
     def __init__(self, config: GymEnvironmentConfig) -> None:
         super().__init__(config, "PokemonRed.gb", "has_pokedex.state")
@@ -30,7 +31,7 @@ class PokemonEnvironment(PyboyEnvironment):
 
     def sample_action(self) -> int:
         return np.random.randint(0, len(self.valid_actions))
-    
+
     def _stats_to_state(self, game_stats: Dict[str, any]) -> List[any]:
         state: List[any] = []
         return state

--- a/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
+++ b/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
@@ -30,7 +30,9 @@ class PokemonEnvironment(PyboyEnvironment):
         ]
 
     def sample_action(self) -> int:
-        return np.random.randint(0, len(self.valid_actions))
+        return np.random.uniform(
+                self.min_action_value, self.max_action_value, size=self.action_num
+            )
 
     def _stats_to_state(self, game_stats: Dict[str, any]) -> List[any]:
         state: List[any] = []

--- a/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
+++ b/scripts/envrionments/pyboy/pokemon/pokemon_environment.py
@@ -31,8 +31,8 @@ class PokemonEnvironment(PyboyEnvironment):
 
     def sample_action(self) -> int:
         return np.random.uniform(
-                self.min_action_value, self.max_action_value, size=self.action_num
-            )
+            self.min_action_value, self.max_action_value, size=self.action_num
+        )
 
     def _stats_to_state(self, game_stats: Dict[str, any]) -> List[any]:
         state: List[any] = []

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -3,6 +3,7 @@ This script is used to train reinforcement learning agents in DMCS/OpenAI/pyboy.
 The main function parses command-line arguments, creates the environment, network, 
 and memory instances, and then trains the agent using the specified algorithm.
 """
+
 import logging
 from datetime import datetime
 from pathlib import Path

--- a/scripts/train_loops/policy_loop.py
+++ b/scripts/train_loops/policy_loop.py
@@ -106,7 +106,7 @@ def policy_based_train(
             logging.info(
                 f"Running Exploration Steps {total_step_counter+1}/{max_steps_exploration}"
             )
-            
+
             action_env = env.sample_action()
 
             # algorithm range [-1, 1] - note for DMCS this is redudenant but required for openai

--- a/scripts/train_loops/policy_loop.py
+++ b/scripts/train_loops/policy_loop.py
@@ -106,10 +106,9 @@ def policy_based_train(
             logging.info(
                 f"Running Exploration Steps {total_step_counter+1}/{max_steps_exploration}"
             )
-            # action range the env uses [e.g. -2 , 2 for pendulum]
-            action_env = np.random.uniform(
-                env.min_action_value, env.max_action_value, size=env.action_num
-            )
+            
+            action_env = env.sample_action()
+
             # algorithm range [-1, 1] - note for DMCS this is redudenant but required for openai
             action = hlp.normalize(
                 action_env, env.max_action_value, env.min_action_value


### PR DESCRIPTION
Moves action sampling inside the environment wrapper.

OpenAI gym will use `env.action_space.sample()`
DMCS gym will use 'np.random.rand()'
