### PR TITLE
Add support for number steps per train policy

### DIFF
--- a/scripts/train_loops/policy_loop.py
+++ b/scripts/train_loops/policy_loop.py
@@ -144,11 +144,13 @@ def policy_based_train(
         state = next_state
         episode_reward += reward_extrinsic  # Note we only track the extrinsic reward for the episode for proper comparison
 
-        if total_step_counter >= max_steps_exploration and total_step_counter % number_steps_per_train_policy == 0:
+        if (
+            total_step_counter >= max_steps_exploration
+            and total_step_counter % number_steps_per_train_policy == 0
+        ):
             for _ in range(G):
                 experience = memory.sample(batch_size)
                 info = agent.train_policy(experience)
-
 
         if (total_step_counter + 1) % number_steps_per_evaluation == 0:
             evaluate = True

--- a/scripts/train_loops/policy_loop.py
+++ b/scripts/train_loops/policy_loop.py
@@ -73,6 +73,7 @@ def policy_based_train(
     max_steps_training = train_config.max_steps_training
     max_steps_exploration = train_config.max_steps_exploration
     number_steps_per_evaluation = train_config.number_steps_per_evaluation
+    number_steps_per_train_policy = train_config.number_steps_per_train_policy
 
     # Algorthm specific attributes - e.g. NaSA-TD3 dd
     intrinsic_on = (
@@ -143,11 +144,11 @@ def policy_based_train(
         state = next_state
         episode_reward += reward_extrinsic  # Note we only track the extrinsic reward for the episode for proper comparison
 
-        if total_step_counter >= max_steps_exploration:
+        if total_step_counter >= max_steps_exploration and total_step_counter % number_steps_per_train_policy == 0:
             for _ in range(G):
                 experience = memory.sample(batch_size)
                 info = agent.train_policy(experience)
-                # record.log_info(info, display=False)
+
 
         if (total_step_counter + 1) % number_steps_per_evaluation == 0:
             evaluate = True


### PR DESCRIPTION
Add support for number steps per train policy from new cares_rl config value.

This parameter is for determining how frequency we update policy in relation to environment steps.

eg. we can train policy after stepping in the environment 32 times