### PR TITLE
Convert full_algorithm_test.sh to python equivalent

### DIFF
--- a/scripts/benchmark_alg.py
+++ b/scripts/benchmark_alg.py
@@ -1,0 +1,55 @@
+import sys
+from run import main as run_main
+from io import StringIO
+from typing import List
+
+# The equivalent of bash's domain-task map
+dmcs_tasks = {
+    "acrobot": "swingup",
+    "ball_in_cup": "catch",
+    "cartpole": "swingup",
+    "cheetah": "run",
+    "finger": "turn_hard",
+    "hopper": "hop",
+    "humanoid": "run",
+    "reacher": "hard",
+    "walker": "walk",
+}
+
+def run_with_args_and_stdin(args_list: List[str], stdin_str: str = ""):
+    """Simulate CLI args and stdin, then call run.py's main()."""
+    old_argv = sys.argv.copy()
+    old_stdin = sys.stdin
+    try:
+        sys.argv = ["run.py"] + args_list
+        sys.stdin = StringIO(stdin_str)
+        run_main()
+    finally:
+        sys.argv = old_argv
+        sys.stdin = old_stdin
+
+def main():
+    # CLI argument parsing (simple mimic of the bash version)
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <required_arg> <run_name> [optional_args...]")
+        sys.exit(1)
+
+    required_arg = sys.argv[1]
+    input_name = sys.argv[2] if len(sys.argv) >= 3 else ""
+    optional_args = sys.argv[3:] if len(sys.argv) > 3 else []
+
+    for domain, task in dmcs_tasks.items():
+        print(f"Running: domain={domain}, task={task}")
+        args = [
+            "train", "cli",
+            "--gym", "dmcs",
+            "--domain", domain,
+            "--task", task,
+            required_arg,
+            "--seeds", "10", "20", "30", "40", "50",
+            *optional_args
+        ]
+        run_with_args_and_stdin(args, stdin_str=input_name)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark_alg.py
+++ b/scripts/benchmark_alg.py
@@ -16,6 +16,7 @@ dmcs_tasks = {
     "walker": "walk",
 }
 
+
 def run_with_args_and_stdin(args_list: List[str], stdin_str: str = ""):
     """Simulate CLI args and stdin, then call run.py's main()."""
     old_argv = sys.argv.copy()
@@ -27,6 +28,7 @@ def run_with_args_and_stdin(args_list: List[str], stdin_str: str = ""):
     finally:
         sys.argv = old_argv
         sys.stdin = old_stdin
+
 
 def main():
     # CLI argument parsing (simple mimic of the bash version)
@@ -41,15 +43,25 @@ def main():
     for domain, task in dmcs_tasks.items():
         print(f"Running: domain={domain}, task={task}")
         args = [
-            "train", "cli",
-            "--gym", "dmcs",
-            "--domain", domain,
-            "--task", task,
+            "train",
+            "cli",
+            "--gym",
+            "dmcs",
+            "--domain",
+            domain,
+            "--task",
+            task,
             required_arg,
-            "--seeds", "10", "20", "30", "40", "50",
-            *optional_args
+            "--seeds",
+            "10",
+            "20",
+            "30",
+            "40",
+            "50",
+            *optional_args,
         ]
         run_with_args_and_stdin(args, stdin_str=input_name)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When training inside a docker container, the container is very susceptible to losing access to GPU/cuda meaning future training processes created by the bash script are unable to use cuda and do not train. This python equivalent avoids the issue by creating training sessions from inside the initial python process, thus maintaining connection to GPUs through all sessions.