### PR TITLE
Logging Delay

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -282,6 +282,7 @@ def main():
         agent=None,
         record_video=training_config.record_eval_video,
         record_checkpoints=env_config.save_train_checkpoints,
+        checkpoint_interval=training_config.checkpoint_interval,
     )
 
     record.save_configurations(configurations)


### PR DESCRIPTION
Can now set: --checkpoint_interval NUM_EPISODES to delay the saving of the csv files, will see performance gains for tasks with very low steps per episode - e.g. space_gym