### PR TITLE
Drone simulator flag

### DIFF
--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -17,7 +17,9 @@ class DroneEnvironment(GymEnvironment):
 
         # Instantiate the task
 
-        self.env = task_factory.make(config.task, use_simulator = cast(Literal[0,1], config.use_simulator))
+        self.env = task_factory.make(
+            config.task, use_simulator=cast(Literal[0, 1], config.use_simulator)
+        )
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -1,28 +1,14 @@
 from functools import cached_property
 
 import numpy as np
-from drone_gym import (
-    move_to_2d_position,
-    move_to_random_2d_position,
-    move_to_3d_position,
-    move_to_random_3d_position,
-)
-from drone_gym.drone_sim import DroneSim
-from drone_gym.drone import Drone
 from environments.gym_environment import GymEnvironment
 from util.configurations import DroneConfig
+from drone_gym import task_map
 
 
 class DroneEnvironment(GymEnvironment):
     def __init__(self, config: DroneConfig, evaluation: bool = False) -> None:
         super().__init__(config)
-
-        task_map = {
-            "move_to_2d_position": move_to_2d_position.MoveToPosition,
-            "move_to_random_2d_position": move_to_random_2d_position.MoveToRandomPosition,
-            "move_to_3d_position": move_to_3d_position.MoveTo3DPosition,
-            "move_to_random_3d_position": move_to_random_3d_position.MoveToRandom3DPosition,
-        }
 
         # Instantiate the task
         self.env = task_map[config.task]()

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -5,7 +5,7 @@ from typing_extensions import Literal
 import numpy as np
 from environments.gym_environment import GymEnvironment
 from util.configurations import DroneConfig
-from drone_gym import task_map
+from drone_gym import task_factory
 
 
 class DroneEnvironment(GymEnvironment):
@@ -16,9 +16,8 @@ class DroneEnvironment(GymEnvironment):
             raise ValueError("use_simulator must be 0 (real drone) or 1 (simulator)")
 
         # Instantiate the task
-        self.env = task_map[config.task](
-            use_simulator=cast(Literal[0, 1], config.use_simulator)
-        )
+
+        self.env = task_factory.make(config.task, use_simulator = cast(Literal[0,1], config.use_simulator))
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 import numpy as np
-from drone_gym import move_to_position
+from drone_gym import move_to_random_3d_position
 from environments.gym_environment import GymEnvironment
 from util.configurations import GymEnvironmentConfig
 
@@ -10,7 +10,7 @@ class DroneEnvironment(GymEnvironment):
     def __init__(self, config: GymEnvironmentConfig, evaluation: bool = False) -> None:
         super().__init__(config)
 
-        self.env = move_to_position.MoveToPosition()
+        self.env = move_to_random_3d_position.MoveToRandom3DPosition()
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 import numpy as np
-from drone_gym import move_to_random_3d_position
+from drone_gym import move_to_2d_position, move_to_random_2d_position, move_to_3d_position, move_to_random_3d_position
 from environments.gym_environment import GymEnvironment
 from util.configurations import GymEnvironmentConfig
 
@@ -10,7 +10,15 @@ class DroneEnvironment(GymEnvironment):
     def __init__(self, config: GymEnvironmentConfig, evaluation: bool = False) -> None:
         super().__init__(config)
 
-        self.env = move_to_random_3d_position.MoveToRandom3DPosition()
+        task_map = {
+            "move_to_2d_position": move_to_2d_position.MoveToPosition,
+            "move_to_random_2d_position": move_to_random_2d_position.MoveToRandomPosition,
+            "move_to_3d_position": move_to_3d_position.MoveTo3DPosition,
+            "move_to_random_3d_position": move_to_random_3d_position.MoveToRandom3DPosition,
+        }
+
+        # self.env = move_to_random_3d_position.MoveToRandom3DPosition()
+        self.env = task_map[config.task]()
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -2,6 +2,8 @@ from functools import cached_property
 
 import numpy as np
 from drone_gym import move_to_2d_position, move_to_random_2d_position, move_to_3d_position, move_to_random_3d_position
+from drone_gym.drone_sim import DroneSim
+from drone_gym.drone import Drone
 from environments.gym_environment import GymEnvironment
 from util.configurations import GymEnvironmentConfig
 
@@ -17,8 +19,19 @@ class DroneEnvironment(GymEnvironment):
             "move_to_random_3d_position": move_to_random_3d_position.MoveToRandom3DPosition,
         }
 
-        # self.env = move_to_random_3d_position.MoveToRandom3DPosition()
+        # Instantiate the task
         self.env = task_map[config.task]()
+        
+        # Set the appropriate drone instance based on use_simulator flag
+        use_simulator = getattr(config, 'use_simulator', 1)  # Default to simulator
+        print(f"[DroneEnvironment] config.use_simulator = {getattr(config, 'use_simulator', 'NOT FOUND')}, use_simulator = {use_simulator}")
+        print(f"[DroneEnvironment] config type = {type(config)}, config = {config}")
+        if bool(use_simulator):
+            print("[DroneEnvironment] Instantiating DroneSim...")
+            self.env.drone = DroneSim()
+        else:
+            print("[DroneEnvironment] Instantiating Drone (real hardware)...")
+            self.env.drone = Drone()
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -1,7 +1,12 @@
 from functools import cached_property
 
 import numpy as np
-from drone_gym import move_to_2d_position, move_to_random_2d_position, move_to_3d_position, move_to_random_3d_position
+from drone_gym import (
+    move_to_2d_position,
+    move_to_random_2d_position,
+    move_to_3d_position,
+    move_to_random_3d_position,
+)
 from drone_gym.drone_sim import DroneSim
 from drone_gym.drone import Drone
 from environments.gym_environment import GymEnvironment
@@ -21,10 +26,12 @@ class DroneEnvironment(GymEnvironment):
 
         # Instantiate the task
         self.env = task_map[config.task]()
-        
+
         # Set the appropriate drone instance based on use_simulator flag
-        use_simulator = getattr(config, 'use_simulator', 1)  # Default to simulator
-        print(f"[DroneEnvironment] config.use_simulator = {getattr(config, 'use_simulator', 'NOT FOUND')}, use_simulator = {use_simulator}")
+        use_simulator = getattr(config, "use_simulator", 1)  # Default to simulator
+        print(
+            f"[DroneEnvironment] config.use_simulator = {getattr(config, 'use_simulator', 'NOT FOUND')}, use_simulator = {use_simulator}"
+        )
         print(f"[DroneEnvironment] config type = {type(config)}, config = {config}")
         if bool(use_simulator):
             print("[DroneEnvironment] Instantiating DroneSim...")

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -29,15 +29,9 @@ class DroneEnvironment(GymEnvironment):
 
         # Set the appropriate drone instance based on use_simulator flag
         use_simulator = getattr(config, "use_simulator", 1)  # Default to simulator
-        print(
-            f"[DroneEnvironment] config.use_simulator = {getattr(config, 'use_simulator', 'NOT FOUND')}, use_simulator = {use_simulator}"
-        )
-        print(f"[DroneEnvironment] config type = {type(config)}, config = {config}")
         if bool(use_simulator):
-            print("[DroneEnvironment] Instantiating DroneSim...")
             self.env.drone = DroneSim()
         else:
-            print("[DroneEnvironment] Instantiating Drone (real hardware)...")
             self.env.drone = Drone()
 
     def reset(self, training: bool = True):

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -10,11 +10,11 @@ from drone_gym import (
 from drone_gym.drone_sim import DroneSim
 from drone_gym.drone import Drone
 from environments.gym_environment import GymEnvironment
-from util.configurations import GymEnvironmentConfig
+from util.configurations import DroneConfig
 
 
 class DroneEnvironment(GymEnvironment):
-    def __init__(self, config: GymEnvironmentConfig, evaluation: bool = False) -> None:
+    def __init__(self, config: DroneConfig, evaluation: bool = False) -> None:
         super().__init__(config)
 
         task_map = {
@@ -26,13 +26,6 @@ class DroneEnvironment(GymEnvironment):
 
         # Instantiate the task
         self.env = task_map[config.task]()
-
-        # Set the appropriate drone instance based on use_simulator flag
-        use_simulator = getattr(config, "use_simulator", 1)  # Default to simulator
-        if bool(use_simulator):
-            self.env.drone = DroneSim()
-        else:
-            self.env.drone = Drone()
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -12,11 +12,13 @@ class DroneEnvironment(GymEnvironment):
     def __init__(self, config: DroneConfig, evaluation: bool = False) -> None:
         super().__init__(config)
 
-        if config.use_simulator not in [0,1]:
+        if config.use_simulator not in [0, 1]:
             raise ValueError("use_simulator must be 0 (real drone) or 1 (simulator)")
-        
+
         # Instantiate the task
-        self.env = task_map[config.task](use_simulator = cast(Literal[0,1], config.use_simulator))
+        self.env = task_map[config.task](
+            use_simulator=cast(Literal[0, 1], config.use_simulator)
+        )
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/environments/drone/drone_environment.py
+++ b/scripts/environments/drone/drone_environment.py
@@ -1,4 +1,6 @@
 from functools import cached_property
+from typing import cast
+from typing_extensions import Literal
 
 import numpy as np
 from environments.gym_environment import GymEnvironment
@@ -10,8 +12,11 @@ class DroneEnvironment(GymEnvironment):
     def __init__(self, config: DroneConfig, evaluation: bool = False) -> None:
         super().__init__(config)
 
+        if config.use_simulator not in [0,1]:
+            raise ValueError("use_simulator must be 0 (real drone) or 1 (simulator)")
+        
         # Instantiate the task
-        self.env = task_map[config.task]()
+        self.env = task_map[config.task](use_simulator = cast(Literal[0,1], config.use_simulator))
 
     def reset(self, training: bool = True):
         return self.env.reset(training)

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -72,7 +72,9 @@ class ShowdownConfig(GymEnvironmentConfig):
 class DroneConfig(GymEnvironmentConfig):
     gym: ClassVar[str] = "drone"
     task: str = "move_to_3d_position"
-    use_simulator: Literal[0,1] = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
+    use_simulator: Literal[0, 1] = (
+        1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
+    )
 
 
 class GripperConfig(GymEnvironmentConfig):

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -71,6 +71,7 @@ class ShowdownConfig(GymEnvironmentConfig):
 
 class DroneConfig(GymEnvironmentConfig):
     gym: ClassVar[str] = "drone"
+    task: str = "move_to_3d_position"
 
 
 class GripperConfig(GymEnvironmentConfig):

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -3,7 +3,7 @@ Configuration class for Gym Environments.
 """
 
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from cares_reinforcement_learning.util.configurations import SubscriptableClass
 
@@ -72,7 +72,7 @@ class ShowdownConfig(GymEnvironmentConfig):
 class DroneConfig(GymEnvironmentConfig):
     gym: ClassVar[str] = "drone"
     task: str = "move_to_3d_position"
-    use_simulator: int = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
+    use_simulator: Literal[0,1] = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
 
 
 class GripperConfig(GymEnvironmentConfig):

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -72,6 +72,7 @@ class ShowdownConfig(GymEnvironmentConfig):
 class DroneConfig(GymEnvironmentConfig):
     gym: ClassVar[str] = "drone"
     task: str = "move_to_3d_position"
+    use_simulator: int = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
 
 
 class GripperConfig(GymEnvironmentConfig):

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -71,10 +71,8 @@ class ShowdownConfig(GymEnvironmentConfig):
 
 class DroneConfig(GymEnvironmentConfig):
     gym: ClassVar[str] = "drone"
-    task: str = "move_to_3d_position"
-    use_simulator: Literal[0, 1] = (
-        1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
-    )
+    task: str = "move_3d"
+    use_simulator: Literal[0,1] = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
 
 
 class GripperConfig(GymEnvironmentConfig):

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -3,7 +3,7 @@ Configuration class for Gym Environments.
 """
 
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 from cares_reinforcement_learning.util.configurations import SubscriptableClass
 

--- a/scripts/util/configurations.py
+++ b/scripts/util/configurations.py
@@ -72,7 +72,7 @@ class ShowdownConfig(GymEnvironmentConfig):
 class DroneConfig(GymEnvironmentConfig):
     gym: ClassVar[str] = "drone"
     task: str = "move_3d"
-    use_simulator: Literal[0,1] = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
+    use_simulator: int = 1  # 1 for simulator (DroneSim), 0 for real drone (Drone)
 
 
 class GripperConfig(GymEnvironmentConfig):


### PR DESCRIPTION
Added a way to select the drone type (whether in simulator or using real crazyflies) through a flag in the run.py command.
The flag "--use_simulator 0" can be used for real drone.
The flag "--use_simulator 1" can be used for simulation. 
By default when "--use_simulator" isn't provided, the flag is 1 and it runs in simulation mode.

Testing:
Drone in simulation works as expected.
Drone in real life could not be tested, though terminal has the same output as it would if Drone class was used instead of DroneSim without a crazyflie connected.

NOTE: this will only work once drone_gym has been updated (which also has an open PR).

